### PR TITLE
Only activate connections marked with autostart

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -390,7 +390,11 @@ impl Interface {
         let mut connections: Vec<model::Connection> = vec![];
 
         if settings.activate_connections {
-            connection.status = Status::Up;
+            connection.status = if connection.autoconnect {
+                Status::Up
+            } else {
+                Status::Down
+            };
         }
 
         if let Some(ethernet) = &self.ethernet {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ pub enum Commands {
         #[arg(long, global = true, env = "W2NM_DRY_RUN")]
         dry_run: bool,
 
-        /// Activate connections immediately
+        /// Activate connections that are marked as autostart immediately
         #[arg(long, global = true, env = "W2NM_ACTIVATE_CONNECTIONS")]
         activate_connections: bool,
     },


### PR DESCRIPTION
When running the migration on a live system with `wicked2nm migrate --activate-connections` it currently brings up all connections. I think it would be better to only activate connections that are marked with `STARTMODE=auto` in wicked.