### PR TITLE
Apply dhcp settings to mirror wicked client id

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -602,43 +602,47 @@ impl Interface {
             }
         }
 
-        let mut dhcp4_settings: Option<Dhcp4Settings> = None;
+        let mut dhcp4_settings: Dhcp4Settings = Dhcp4Settings::default();
+        let mut dhcp6_settings: Dhcp6Settings = Dhcp6Settings::default();
+
         if let Some(ipv4_dhcp) = &self.ipv4_dhcp {
-            let mut dhcp_settings = Dhcp4Settings::default();
             if let Some(hostname) = &ipv4_dhcp.hostname {
-                dhcp_settings.send_hostname = Some(true);
+                dhcp4_settings.send_hostname = Some(true);
                 if let Some(netconfig_dhcp) = netconfig_dhcp {
                     if netconfig_dhcp.dhclient_hostname_option != HostnameOption::Auto {
-                        dhcp_settings.hostname = Some(hostname.clone());
+                        dhcp4_settings.hostname = Some(hostname.clone());
                     }
                 } else {
-                    dhcp_settings.hostname = Some(hostname.clone());
+                    dhcp4_settings.hostname = Some(hostname.clone());
                 }
             } else {
-                dhcp_settings.send_hostname = Some(false);
+                dhcp4_settings.send_hostname = Some(false);
             }
-            dhcp_settings.send_release = Some(ipv4_dhcp.release_lease);
-            dhcp4_settings = Some(dhcp_settings);
+            dhcp4_settings.send_release = Some(ipv4_dhcp.release_lease);
+            dhcp4_settings.client_id = model::DhcpClientId::Ipv6Duid;
+            dhcp4_settings.iaid = model::DhcpIaid::Mac;
+            dhcp6_settings.duid = model::DhcpDuid::Llt;
         }
+        let dhcp4_settings: Option<Dhcp4Settings> = Some(dhcp4_settings);
 
-        let mut dhcp6_settings: Option<Dhcp6Settings> = None;
         if let Some(ipv6_dhcp) = &self.ipv6_dhcp {
-            let mut dhcp_settings = Dhcp6Settings::default();
             if let Some(hostname) = &ipv6_dhcp.hostname {
-                dhcp_settings.send_hostname = Some(true);
+                dhcp6_settings.send_hostname = Some(true);
                 if let Some(netconfig_dhcp) = netconfig_dhcp {
                     if netconfig_dhcp.dhclient6_hostname_option != HostnameOption::Auto {
-                        dhcp_settings.hostname = Some(hostname.clone());
+                        dhcp6_settings.hostname = Some(hostname.clone());
                     }
                 } else {
-                    dhcp_settings.hostname = Some(hostname.clone());
+                    dhcp6_settings.hostname = Some(hostname.clone());
                 }
             } else {
-                dhcp_settings.send_hostname = Some(false);
+                dhcp6_settings.send_hostname = Some(false);
             }
-            dhcp_settings.send_release = Some(ipv6_dhcp.release_lease);
-            dhcp6_settings = Some(dhcp_settings);
+            dhcp6_settings.send_release = Some(ipv6_dhcp.release_lease);
+            dhcp6_settings.iaid = model::DhcpIaid::Mac;
+            dhcp6_settings.duid = model::DhcpDuid::Llt;
         }
+        let dhcp6_settings: Option<Dhcp6Settings> = Some(dhcp6_settings);
 
         let mut ip6_privacy: Option<i32> = None;
         if let Some(privacy) = &self.ipv6.privacy {

--- a/tests/bond_active-backup/system-connections/bond0.nmconnection
+++ b/tests/bond_active-backup/system-connections/bond0.nmconnection
@@ -18,6 +18,8 @@ use_carrier=1
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=0
@@ -26,6 +28,8 @@ method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=0

--- a/tests/bond_active-backup2/system-connections/bond0.nmconnection
+++ b/tests/bond_active-backup2/system-connections/bond0.nmconnection
@@ -18,12 +18,16 @@ use_carrier=1
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname=false
 ignore-auto-dns=true
 method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname=false
 ignore-auto-dns=true
 ip6-privacy=1

--- a/tests/hostname/system-connections/eth9.nmconnection
+++ b/tests/hostname/system-connections/eth9.nmconnection
@@ -9,7 +9,9 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
 dhcp-hostname=test-hostname-v4
+dhcp-iaid=mac
 dhcp-send-hostname=1
 dhcp-send-release=0
 ignore-auto-dns=true
@@ -17,7 +19,9 @@ method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
 dhcp-hostname=test-hostname-v6
+dhcp-iaid=mac
 dhcp-send-hostname=1
 dhcp-send-release=0
 ignore-auto-dns=true

--- a/tests/hostname2/system-connections/eth9.nmconnection
+++ b/tests/hostname2/system-connections/eth9.nmconnection
@@ -9,6 +9,8 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=0
@@ -17,6 +19,8 @@ method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=0

--- a/tests/hostname3/system-connections/eth9.nmconnection
+++ b/tests/hostname3/system-connections/eth9.nmconnection
@@ -9,13 +9,17 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
 dhcp-hostname=test-hostname-v4
+dhcp-iaid=mac
 ignore-auto-dns=true
 method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
 dhcp-hostname=test-hostname-v6
+dhcp-iaid=mac
 ignore-auto-dns=true
 ip6-privacy=1
 method=auto

--- a/tests/hostname4/system-connections/eth9.nmconnection
+++ b/tests/hostname4/system-connections/eth9.nmconnection
@@ -9,12 +9,16 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname=false
 ignore-auto-dns=true
 method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname=false
 ignore-auto-dns=true
 ip6-privacy=1

--- a/tests/ipv4+6_dhcp/system-connections/eth9.nmconnection
+++ b/tests/ipv4+6_dhcp/system-connections/eth9.nmconnection
@@ -9,6 +9,8 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=0
@@ -16,6 +18,8 @@ method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=0

--- a/tests/ipv4+6_dhcp2/system-connections/eth9.nmconnection
+++ b/tests/ipv4+6_dhcp2/system-connections/eth9.nmconnection
@@ -9,11 +9,15 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname=false
 method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname=false
 ip6-privacy=1
 method=auto

--- a/tests/ipv6_dhcp/system-connections/eth5.nmconnection
+++ b/tests/ipv6_dhcp/system-connections/eth5.nmconnection
@@ -14,6 +14,8 @@ method=disabled
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname=1
 dhcp-send-release=0
 ignore-auto-dns=true

--- a/tests/ipv6_dhcp/system-connections/eth6.nmconnection
+++ b/tests/ipv6_dhcp/system-connections/eth6.nmconnection
@@ -14,6 +14,8 @@ method=disabled
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname=1
 dhcp-send-release=0
 ignore-auto-dns=true

--- a/tests/ipv6_dhcp2/system-connections/eth5.nmconnection
+++ b/tests/ipv6_dhcp2/system-connections/eth5.nmconnection
@@ -14,6 +14,8 @@ method=disabled
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 ignore-auto-dns=true
 ip6-privacy=1
 method=dhcp

--- a/tests/ipv6_dhcp2/system-connections/eth6.nmconnection
+++ b/tests/ipv6_dhcp2/system-connections/eth6.nmconnection
@@ -14,6 +14,8 @@ method=disabled
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 ignore-auto-dns=true
 ip6-privacy=1
 method=auto

--- a/tests/ovs-bridge1.1/wicked_xml/config.xml
+++ b/tests/ovs-bridge1.1/wicked_xml/config.xml
@@ -18,8 +18,8 @@
     <privacy>prefer-public</privacy>
   </ipv6>
 </interface>
-<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap10">
-  <name>tap10</name>
+<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap20">
+  <name>tap20</name>
   <control>
     <mode>boot</mode>
   </control>
@@ -38,8 +38,8 @@
     <enabled>false</enabled>
   </ipv6>
 </interface>
-<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap20">
-  <name>tap20</name>
+<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap10">
+  <name>tap10</name>
   <control>
     <mode>boot</mode>
   </control>

--- a/tests/ovs-bridge1/wicked_xml/config.xml
+++ b/tests/ovs-bridge1/wicked_xml/config.xml
@@ -18,8 +18,8 @@
     <privacy>prefer-public</privacy>
   </ipv6>
 </interface>
-<interface origin="compat:suse:/tests/ovs-bridge1/netconfig/ifcfg-tap10">
-  <name>tap10</name>
+<interface origin="compat:suse:/tests/ovs-bridge1/netconfig/ifcfg-tap20">
+  <name>tap20</name>
   <control>
     <mode>boot</mode>
   </control>
@@ -38,8 +38,8 @@
     <enabled>false</enabled>
   </ipv6>
 </interface>
-<interface origin="compat:suse:/tests/ovs-bridge1/netconfig/ifcfg-tap20">
-  <name>tap20</name>
+<interface origin="compat:suse:/tests/ovs-bridge1/netconfig/ifcfg-tap10">
+  <name>tap10</name>
   <control>
     <mode>boot</mode>
   </control>

--- a/tests/ovs-bridge2.1/wicked_xml/config.xml
+++ b/tests/ovs-bridge2.1/wicked_xml/config.xml
@@ -1,35 +1,3 @@
-<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en0">
-  <name>en0</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link>
-    <master>ovsbrA</master>
-    <port type="ovs-bridge"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en1">
-  <name>en1</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link>
-    <master>ovsbrB</master>
-    <port type="ovs-bridge"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
-  </ipv6>
-</interface>
 <interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-ovsbrA">
   <name>ovsbrA</name>
   <control>
@@ -48,6 +16,22 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
+  </ipv6>
+</interface>
+<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en1">
+  <name>en1</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link>
+    <master>ovsbrB</master>
+    <port type="ovs-bridge"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
   </ipv6>
 </interface>
 <interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-ovsbrB">
@@ -73,5 +57,21 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
+  </ipv6>
+</interface>
+<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en0">
+  <name>en0</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link>
+    <master>ovsbrA</master>
+    <port type="ovs-bridge"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/ovs-bridge2/wicked_xml/config.xml
+++ b/tests/ovs-bridge2/wicked_xml/config.xml
@@ -1,35 +1,3 @@
-<interface origin="compat:suse:/tests/ovs-bridge2/netconfig/ifcfg-en0">
-  <name>en0</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link>
-    <master>ovsbrA</master>
-    <port type="ovs-bridge"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/ovs-bridge2/netconfig/ifcfg-en1">
-  <name>en1</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link>
-    <master>ovsbrB</master>
-    <port type="ovs-bridge"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
-  </ipv6>
-</interface>
 <interface origin="compat:suse:/tests/ovs-bridge2/netconfig/ifcfg-ovsbrA">
   <name>ovsbrA</name>
   <control>
@@ -48,6 +16,22 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
+  </ipv6>
+</interface>
+<interface origin="compat:suse:/tests/ovs-bridge2/netconfig/ifcfg-en1">
+  <name>en1</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link>
+    <master>ovsbrB</master>
+    <port type="ovs-bridge"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
   </ipv6>
 </interface>
 <interface origin="compat:suse:/tests/ovs-bridge2/netconfig/ifcfg-ovsbrB">
@@ -73,5 +57,21 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
+  </ipv6>
+</interface>
+<interface origin="compat:suse:/tests/ovs-bridge2/netconfig/ifcfg-en0">
+  <name>en0</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link>
+    <master>ovsbrA</master>
+    <port type="ovs-bridge"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/send_release/system-connections/eth9.nmconnection
+++ b/tests/send_release/system-connections/eth9.nmconnection
@@ -9,6 +9,8 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=1
@@ -17,6 +19,8 @@ method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname-deprecated=false
 dhcp-send-hostname=0
 dhcp-send-release=1

--- a/tests/send_release2/system-connections/eth9.nmconnection
+++ b/tests/send_release2/system-connections/eth9.nmconnection
@@ -9,12 +9,16 @@ interface-name=eth9
 [match]
 
 [ipv4]
+dhcp-client-id=ipv6-duid
+dhcp-iaid=mac
 dhcp-send-hostname=false
 ignore-auto-dns=true
 method=auto
 
 [ipv6]
 addr-gen-mode=default
+dhcp-duid=llt
+dhcp-iaid=mac
 dhcp-send-hostname=false
 ignore-auto-dns=true
 ip6-privacy=1


### PR DESCRIPTION
## Description
This PR sets the relevant NM config options that are required so the DHCPv4 client identifier is the same between wicked and NM. I haven't tested DHCPv6 yet.

What's required to set is
```
ipv4.dhcp-client-id=ipv6-duid
ipv6.dhcp-duid=llt
ipv4.dhcp-iaid=mac
```
## Screenshots
wicked:
<img width="825" height="176" alt="image" src="https://github.com/user-attachments/assets/e1368210-c407-45a8-b6b7-558247d4d5ae" />
NM without changes:
<img width="705" height="88" alt="image" src="https://github.com/user-attachments/assets/d326410e-e073-426b-85fd-3f6eaa4e23a9" />
NM with changes:
<img width="823" height="177" alt="image" src="https://github.com/user-attachments/assets/6f35e533-4d99-4fbb-a1d5-bd4453f6c773" />
