### PR TITLE
Fix continue migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "testing_logger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1721,7 @@ dependencies = [
  "simplelog",
  "strum 0.25.0",
  "strum_macros 0.25.3",
+ "testing_logger",
  "tokio",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ dotenv = "0.15.0"
 serde_path_to_error = "0.1.16"
 globset = { version = "0.4.16", default-features = false }
 
+[dev-dependencies]
+testing_logger = "0.1.1"
+
 [[bin]]
 name = "wicked2nm"
 path = "src/main.rs"

--- a/src/infiniband.rs
+++ b/src/infiniband.rs
@@ -109,15 +109,21 @@ mod tests {
             ..Default::default()
         };
 
+        testing_logger::setup();
+
         let connections = infiniband_child_interface.to_connection(&None);
         assert!(connections.is_ok());
 
         // Check multicast warning is generated
-        assert_eq!(connections.as_ref().unwrap().warnings.len(), 1);
-        assert_eq!(
-            connections.as_ref().unwrap().warnings[0].to_string(),
-            "Infiniband multicast isn't supported by NetworkManager"
-        );
+        assert!(connections.as_ref().unwrap().has_warnings);
+
+        testing_logger::validate(|captured_logs| {
+            assert_eq!(captured_logs.len(), 1);
+            assert_eq!(
+                captured_logs[0].body,
+                "Infiniband multicast isn't supported by NetworkManager"
+            );
+        });
 
         let connection = &connections.unwrap().connections[0];
         let model::ConnectionConfig::Infiniband(infiniband_child) = &connection.config else {

--- a/src/netconfig_dhcp.rs
+++ b/src/netconfig_dhcp.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 pub struct NetconfigDhcp {
     pub dhclient_hostname_option: HostnameOption,
     pub dhclient6_hostname_option: HostnameOption,
+    pub has_warning: bool,
 }
 
 #[derive(Default, Debug, PartialEq, Serialize)]
@@ -25,9 +26,16 @@ impl From<String> for HostnameOption {
     }
 }
 
-pub fn read_netconfig_dhcp(path: impl AsRef<Path>) -> Result<NetconfigDhcp, anyhow::Error> {
+pub fn read_netconfig_dhcp(path: &Path) -> Result<NetconfigDhcp, anyhow::Error> {
+    if !path.exists() {
+        log::warn!("Missing netconfig dhcp file {}", path.display());
+        return Ok(NetconfigDhcp {
+            has_warning: true,
+            ..Default::default()
+        });
+    }
     if let Err(e) = dotenv::from_filename(path) {
-        return Err(e.into());
+        anyhow::bail!(e);
     };
     Ok(handle_netconfig_dhcp_values())
 }


### PR DESCRIPTION
We should only have one single place, where we show the
`--continue-migration` hint to the customer. Otherwise
he could read this, use it, but actually accept warnings
which will occur later in the code.