### PR TITLE
wicked2nm 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "wicked2nm"
-version = "1.1.0"
+version = "1.3.0"
 dependencies = [
  "agama-network",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wicked2nm"
-version = "1.1.0"
+version = "1.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What's Changed
* Issue only a info when dhcp.update is non default https://github.com/openSUSE/wicked2nm/pull/42
* Add ipv4_static broadcast https://github.com/openSUSE/wicked2nm/pull/45
* Apply dhcp settings to mirror wicked client id https://github.com/openSUSE/wicked2nm/pull/41
* Fix test.sh, fail if migration succeed but expect fail https://github.com/openSUSE/wicked2nm/pull/46
* Fix sysctl handling https://github.com/openSUSE/wicked2nm/pull/44
* Avoid cloning in parsing of route https://github.com/openSUSE/wicked2nm/pull/49
* Fix continue migration to show all warnings beforehand https://github.com/openSUSE/wicked2nm/pull/47
* Improve warning messages - show interface, element names https://github.com/openSUSE/wicked2nm/pull/50
* Remove unwrap in route parsing https://github.com/openSUSE/wicked2nm/pull/51