### PR TITLE
wicked2nm 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "wicked2nm"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "agama-network",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wicked2nm"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What's Changed
* Activate only connections if present in the current system in https://github.com/openSUSE/wicked2nm/pull/54
* Improve error output, exit codes and add flag to disable user hints in https://github.com/openSUSE/wicked2nm/pull/57
* Add support for autoip-fallback in https://github.com/openSUSE/wicked2nm/pull/56