### PR TITLE
wicked2nm 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "wicked2nm"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "agama-network",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wicked2nm"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What's Changed
* Enable Leap16.0 for integration tests ci in https://github.com/openSUSE/wicked2nm/pull/59
* build(deps): bump bytes from 1.10.1 to 1.11.1 in https://github.com/openSUSE/wicked2nm/pull/63
* Update time to 0.3.47 in https://github.com/openSUSE/wicked2nm/pull/65 (CVE-2026-25727)