### PR TITLE
wicked2nm 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "wicked2nm"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "agama-network",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wicked2nm"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What's Changed
* Respect create-cid and client-id in interface xml https://github.com/openSUSE/wicked2nm/pull/64
* Require at least one file for migrate and show commands https://github.com/openSUSE/wicked2nm/pull/68
* Perform extra validation for correct xml file https://github.com/openSUSE/wicked2nm/pull/69
* Improve `dhcp.update` default and user info https://github.com/openSUSE/wicked2nm/pull/70
* Update dependencies https://github.com/openSUSE/wicked2nm/pull/71
* Allow DHCP+staticIP addresses  https://github.com/openSUSE/wicked2nm/pull/72
* Fix DHCLIENT_SET_DEFAULT_ROUTE="no" https://github.com/openSUSE/wicked2nm/pull/73
* Handle 'STATIC_FALLBACK' and 'NetworkManager' in netconfig https://github.com/openSUSE/wicked2nm/pull/75
* Implement team to bond migration https://github.com/openSUSE/wicked2nm/pull/74
* Update agama-network to remove dependency on curl https://github.com/openSUSE/wicked2nm/pull/76