### PR TITLE
Tests: Sort wicked show-config output by interface name

### DIFF
--- a/tests/dhcp4_client_id/wicked_xml/config.xml
+++ b/tests/dhcp4_client_id/wicked_xml/config.xml
@@ -1,34 +1,3 @@
-<interface origin="compat:suse:/tests/dhcp4_client_id/netconfig/ifcfg-eth6">
-  <name>eth6</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link/>
-  <ipv4>
-    <enabled>true</enabled>
-  </ipv4>
-  <ipv4:dhcp>
-    <enabled>true</enabled>
-    <flags>group</flags>
-    <update>default-route,hostname,dns,nis,ntp,nds,mtu,tz,boot</update>
-    <recover-lease>true</recover-lease>
-    <release-lease>false</release-lease>
-  </ipv4:dhcp>
-  <ipv6>
-    <enabled>true</enabled>
-    <privacy>prefer-public</privacy>
-  </ipv6>
-  <ipv6:dhcp>
-    <enabled>true</enabled>
-    <flags>group</flags>
-    <update>hostname,dns,nis,ntp,tz,boot</update>
-    <mode>auto</mode>
-    <rapid-commit>true</rapid-commit>
-    <recover-lease>true</recover-lease>
-    <refresh-lease>false</refresh-lease>
-    <release-lease>false</release-lease>
-  </ipv6:dhcp>
-</interface>
 <interface origin="compat:suse:/tests/dhcp4_client_id/netconfig/ifcfg-eth5">
   <name>eth5</name>
   <control>
@@ -61,8 +30,8 @@
     <release-lease>false</release-lease>
   </ipv6:dhcp>
 </interface>
-<interface origin="compat:suse:/tests/dhcp4_client_id/netconfig/ifcfg-eth9">
-  <name>eth9</name>
+<interface origin="compat:suse:/tests/dhcp4_client_id/netconfig/ifcfg-eth6">
+  <name>eth6</name>
   <control>
     <mode>boot</mode>
   </control>
@@ -76,7 +45,6 @@
     <update>default-route,hostname,dns,nis,ntp,nds,mtu,tz,boot</update>
     <recover-lease>true</recover-lease>
     <release-lease>false</release-lease>
-    <create-cid>rfc4361</create-cid>
   </ipv4:dhcp>
   <ipv6>
     <enabled>true</enabled>
@@ -141,6 +109,38 @@
     <recover-lease>true</recover-lease>
     <release-lease>false</release-lease>
     <create-cid>rfc2132</create-cid>
+  </ipv4:dhcp>
+  <ipv6>
+    <enabled>true</enabled>
+    <privacy>prefer-public</privacy>
+  </ipv6>
+  <ipv6:dhcp>
+    <enabled>true</enabled>
+    <flags>group</flags>
+    <update>hostname,dns,nis,ntp,tz,boot</update>
+    <mode>auto</mode>
+    <rapid-commit>true</rapid-commit>
+    <recover-lease>true</recover-lease>
+    <refresh-lease>false</refresh-lease>
+    <release-lease>false</release-lease>
+  </ipv6:dhcp>
+</interface>
+<interface origin="compat:suse:/tests/dhcp4_client_id/netconfig/ifcfg-eth9">
+  <name>eth9</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link/>
+  <ipv4>
+    <enabled>true</enabled>
+  </ipv4>
+  <ipv4:dhcp>
+    <enabled>true</enabled>
+    <flags>group</flags>
+    <update>default-route,hostname,dns,nis,ntp,nds,mtu,tz,boot</update>
+    <recover-lease>true</recover-lease>
+    <release-lease>false</release-lease>
+    <create-cid>rfc4361</create-cid>
   </ipv4:dhcp>
   <ipv6>
     <enabled>true</enabled>

--- a/tests/dhcp4_default_route/wicked_xml/config.xml
+++ b/tests/dhcp4_default_route/wicked_xml/config.xml
@@ -1,3 +1,34 @@
+<interface origin="compat:suse:/tests/dhcp4_default_route/netconfig/ifcfg-eth10">
+  <name>eth10</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link/>
+  <ipv4>
+    <enabled>true</enabled>
+  </ipv4>
+  <ipv4:dhcp>
+    <enabled>true</enabled>
+    <flags>group</flags>
+    <update>default-route,hostname,dns,nis,ntp,nds,mtu,tz,boot</update>
+    <recover-lease>true</recover-lease>
+    <release-lease>false</release-lease>
+  </ipv4:dhcp>
+  <ipv6>
+    <enabled>true</enabled>
+    <privacy>prefer-public</privacy>
+  </ipv6>
+  <ipv6:dhcp>
+    <enabled>true</enabled>
+    <flags>group</flags>
+    <update>hostname,dns,nis,ntp,tz,boot</update>
+    <mode>auto</mode>
+    <rapid-commit>true</rapid-commit>
+    <recover-lease>true</recover-lease>
+    <refresh-lease>false</refresh-lease>
+    <release-lease>false</release-lease>
+  </ipv6:dhcp>
+</interface>
 <interface origin="compat:suse:/tests/dhcp4_default_route/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -34,37 +65,6 @@
       </nexthop>
     </route>
   </ipv4:static>
-  <ipv6>
-    <enabled>true</enabled>
-    <privacy>prefer-public</privacy>
-  </ipv6>
-  <ipv6:dhcp>
-    <enabled>true</enabled>
-    <flags>group</flags>
-    <update>hostname,dns,nis,ntp,tz,boot</update>
-    <mode>auto</mode>
-    <rapid-commit>true</rapid-commit>
-    <recover-lease>true</recover-lease>
-    <refresh-lease>false</refresh-lease>
-    <release-lease>false</release-lease>
-  </ipv6:dhcp>
-</interface>
-<interface origin="compat:suse:/tests/dhcp4_default_route/netconfig/ifcfg-eth10">
-  <name>eth10</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link/>
-  <ipv4>
-    <enabled>true</enabled>
-  </ipv4>
-  <ipv4:dhcp>
-    <enabled>true</enabled>
-    <flags>group</flags>
-    <update>default-route,hostname,dns,nis,ntp,nds,mtu,tz,boot</update>
-    <recover-lease>true</recover-lease>
-    <release-lease>false</release-lease>
-  </ipv4:dhcp>
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>

--- a/tests/ovs-bridge1.1/wicked_xml/config.xml
+++ b/tests/ovs-bridge1.1/wicked_xml/config.xml
@@ -18,8 +18,8 @@
     <privacy>prefer-public</privacy>
   </ipv6>
 </interface>
-<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap20">
-  <name>tap20</name>
+<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap10">
+  <name>tap10</name>
   <control>
     <mode>boot</mode>
   </control>
@@ -38,8 +38,8 @@
     <enabled>false</enabled>
   </ipv6>
 </interface>
-<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap10">
-  <name>tap10</name>
+<interface origin="compat:suse:/tests/ovs-bridge1.1/netconfig/ifcfg-tap20">
+  <name>tap20</name>
   <control>
     <mode>boot</mode>
   </control>

--- a/tests/ovs-bridge2.1/wicked_xml/config.xml
+++ b/tests/ovs-bridge2.1/wicked_xml/config.xml
@@ -1,3 +1,35 @@
+<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en0">
+  <name>en0</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link>
+    <master>ovsbrA</master>
+    <port type="ovs-bridge"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
+<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en1">
+  <name>en1</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <link>
+    <master>ovsbrB</master>
+    <port type="ovs-bridge"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-ovsbrA">
   <name>ovsbrA</name>
   <control>
@@ -16,22 +48,6 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en1">
-  <name>en1</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link>
-    <master>ovsbrB</master>
-    <port type="ovs-bridge"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>
 <interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-ovsbrB">
@@ -57,21 +73,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/ovs-bridge2.1/netconfig/ifcfg-en0">
-  <name>en0</name>
-  <control>
-    <mode>boot</mode>
-  </control>
-  <link>
-    <master>ovsbrA</master>
-    <port type="ovs-bridge"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_activebackup_arp/wicked_xml/config.xml
+++ b/tests/team_activebackup_arp/wicked_xml/config.xml
@@ -16,6 +16,24 @@
     <enabled>false</enabled>
   </ipv6>
 </interface>
+<interface origin="compat:suse:/tests/team_activebackup_arp/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team">
+      <prio>50</prio>
+    </port>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_activebackup_arp/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -65,23 +83,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_activebackup_arp/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team">
-      <prio>50</prio>
-    </port>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_activebackup_notifications/wicked_xml/config.xml
+++ b/tests/team_activebackup_notifications/wicked_xml/config.xml
@@ -1,3 +1,19 @@
+<interface origin="compat:suse:/tests/team_activebackup_notifications/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_activebackup_notifications/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -50,21 +66,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_activebackup_notifications/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_activebackup_nsna/wicked_xml/config.xml
+++ b/tests/team_activebackup_nsna/wicked_xml/config.xml
@@ -1,3 +1,20 @@
+<interface origin="compat:suse:/tests/team_activebackup_nsna/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>true</enabled>
+    <accept-ra>disable</accept-ra>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_activebackup_nsna/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -45,21 +62,4 @@
       <local>2001:db8::1/64</local>
     </address>
   </ipv6:static>
-</interface>
-<interface origin="compat:suse:/tests/team_activebackup_nsna/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>true</enabled>
-    <accept-ra>disable</accept-ra>
-  </ipv6>
 </interface>

--- a/tests/team_lacp_ethtool/wicked_xml/config.xml
+++ b/tests/team_lacp_ethtool/wicked_xml/config.xml
@@ -1,3 +1,19 @@
+<interface origin="compat:suse:/tests/team_lacp_ethtool/netconfig/ifcfg-en0">
+  <name>en0</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_lacp_ethtool/netconfig/ifcfg-en1">
   <name>en1</name>
   <control>
@@ -50,21 +66,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_lacp_ethtool/netconfig/ifcfg-en0">
-  <name>en0</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_loadbalance_txhash/wicked_xml/config.xml
+++ b/tests/team_loadbalance_txhash/wicked_xml/config.xml
@@ -1,3 +1,19 @@
+<interface origin="compat:suse:/tests/team_loadbalance_txhash/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_loadbalance_txhash/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -45,21 +61,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_loadbalance_txhash/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_random/wicked_xml/config.xml
+++ b/tests/team_random/wicked_xml/config.xml
@@ -1,3 +1,19 @@
+<interface origin="compat:suse:/tests/team_random/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_random/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -40,21 +56,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_random/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_roundrobin_arp/wicked_xml/config.xml
+++ b/tests/team_roundrobin_arp/wicked_xml/config.xml
@@ -1,3 +1,19 @@
+<interface origin="compat:suse:/tests/team_roundrobin_arp/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_roundrobin_arp/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -42,21 +58,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_roundrobin_arp/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_roundrobin_arp2/wicked_xml/config.xml
+++ b/tests/team_roundrobin_arp2/wicked_xml/config.xml
@@ -1,3 +1,19 @@
+<interface origin="compat:suse:/tests/team_roundrobin_arp2/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_roundrobin_arp2/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -42,21 +58,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_roundrobin_arp2/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/team_warnings/wicked_xml/config.xml
+++ b/tests/team_warnings/wicked_xml/config.xml
@@ -1,3 +1,19 @@
+<interface origin="compat:suse:/tests/team_warnings/netconfig/ifcfg-eth8">
+  <name>eth8</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+  <link>
+    <master>team0</master>
+    <port type="team"/>
+  </link>
+  <ipv4>
+    <enabled>false</enabled>
+  </ipv4>
+  <ipv6>
+    <enabled>false</enabled>
+  </ipv6>
+</interface>
 <interface origin="compat:suse:/tests/team_warnings/netconfig/ifcfg-eth9">
   <name>eth9</name>
   <control>
@@ -43,21 +59,5 @@
   <ipv6>
     <enabled>true</enabled>
     <privacy>prefer-public</privacy>
-  </ipv6>
-</interface>
-<interface origin="compat:suse:/tests/team_warnings/netconfig/ifcfg-eth8">
-  <name>eth8</name>
-  <control>
-    <mode>hotplug</mode>
-  </control>
-  <link>
-    <master>team0</master>
-    <port type="team"/>
-  </link>
-  <ipv4>
-    <enabled>false</enabled>
-  </ipv4>
-  <ipv6>
-    <enabled>false</enabled>
   </ipv6>
 </interface>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -42,6 +42,23 @@ keep_connection() {
     return 1 # Not found
 }
 
+fixup_interface_xml_order() {
+    local file=${1:?Missing file argument}
+    gawk -v RS='</interface>' '
+/<interface/ {
+    sub(/^[[:space:]]+/, "", $0)
+    match($0, /<name>([^<]+)<\/name>/, m)
+    data[m[1]] = $0
+}
+END {
+    n = asorti(data, sorted)
+    for (i=1; i<=n; i++) {
+        printf "%s</interface>\n", data[sorted[i]]
+    }
+}' "$file" > "$file.tmp" &&
+    mv "$file.tmp" "$file"
+}
+
 refresh_connections() {
     local filename
 
@@ -67,7 +84,7 @@ nm_cleanup() {
         nmcli con delete "$UUID"
         while nmcli -t -f UUID c s | grep -P "^$UUID$" >/dev/null; do
           echo " -> Wait for $NAME($UUID) deletion"
-            sleep 1 
+            sleep 1
         done
     done
 }
@@ -97,7 +114,7 @@ print_help()
 POSITIONAL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
-  opt=$1; 
+  opt=$1;
   shift;
   case $opt in
     -v|--verbose)
@@ -241,6 +258,8 @@ for test_dir in ${TEST_DIRS[@]}; do
         # https://unix.stackexchange.com/a/209744
         regex_esc_test_dir="$(printf '%s' "$test_dir" | sed 's/[\/.[\(*^$+?{|]/\\&/g')"
         sed -i -E 's/[^:]+(\/tests\/'"$regex_esc_test_dir"')/\1/' "$cfg_out"
+
+        fixup_interface_xml_order "$cfg_out"
     fi
 
     log_verbose "RUN: $MIGRATE_WICKED_BIN show $test_dir/wicked_xml"


### PR DESCRIPTION
This has no technical change. It simply reliably sorts the config.xml `<interface>`'s by name.