### PR TITLE
wicked2nm 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "wicked2nm"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "agama-network",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wicked2nm"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What's Changed
* Update agama to fix default vlan flags https://github.com/openSUSE/wicked2nm/pull/78
* Tests: Sort wicked show-config output by interface name https://github.com/openSUSE/wicked2nm/pull/79
* Add leap16.1 to CI https://github.com/openSUSE/wicked2nm/pull/80